### PR TITLE
v0.2.0 alias / docs / hygiene cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,7 +239,7 @@ All tests (including 63 vectors) pass with and without `zeroize`. The library is
   → Reads just 3–5 bytes to extract/validate version (0–3) + magic ("AES")  
   → Errors on invalid magic, short files, or bad reserved bytes  
   → Useful for batch validation, legacy detection, or CLI tools
-  - No crypto/KDF deps, fully `no_std`, <1μs per file
+  - No crypto/KDF deps, <1μs per file
   - 100% tested against all 63 official v0–v3 vectors + edges (invalid/short/malformed)
   - Closes #17
 
@@ -299,7 +299,7 @@ All tests (including 63 vectors) pass with and without `zeroize`. The library is
 - **Upgraded `secure-gate` to v0.5.7** and enabled its new `rand` feature  
   → All cryptographically secure random values (`Aes256Key`, `Iv16`, salts, etc.) are now generated with `SecureRandomExt::random()` from `secure-gate`
   - Removes the duplicated RNG implementation (`src/crypto/rng.rs` → deleted)
-  - Zero-cost, thread-local `OsRng`, lazy-initialized, fully `no_std`-compatible
+  - Zero-cost, thread-local `OsRng`, lazy-initialized
   - Panics on RNG failure (high-assurance crypto standard)
   - No behavior or performance regression — benchmarks remain identical (>160 MiB/s encrypt, >170 MiB/s decrypt)
 
@@ -331,7 +331,6 @@ All 100+ tests (including v0–v3 round-trips and deterministic vectors) continu
   - Deterministic v3 test vectors with known public IV, session IV, and session key
   - KDF edge-case tests (ACKDF, PBKDF2, unicode passwords, empty inputs)
 - Benchmark suite using Criterion.rs (`cargo bench`) with realistic 1 KiB → 10 MiB workloads
-- `#![no_std]`-compatible core (only `std` feature adds convenience wrappers)
 - Detailed documentation and examples in `README.md`
 - CI workflow (GitHub Actions) with full test + bench matrix
 

--- a/benches/iterations.rs
+++ b/benches/iterations.rs
@@ -12,12 +12,12 @@ use std::io::Cursor;
 fn bench_encrypt_iterations(c: &mut Criterion) {
     let mut group = c.benchmark_group("encrypt_iterations");
     group.sample_size(10); // Fewer samples for slow iterations
-    
+
     let password = PasswordString::new("benchmark-password".to_string());
     let plaintext = b"test data for iteration benchmarking";
-    
+
     let iterations = vec![1, 10, 100, 1_000, 10_000, 100_000, 300_000, 500_000];
-    
+
     for &iters in &iterations {
         let id = BenchmarkId::new("iterations", iters);
         group.bench_with_input(id, &iters, |b, &iters| {
@@ -34,19 +34,19 @@ fn bench_encrypt_iterations(c: &mut Criterion) {
             });
         });
     }
-    
+
     group.finish();
 }
 
 fn bench_roundtrip_iterations(c: &mut Criterion) {
     let mut group = c.benchmark_group("roundtrip_iterations");
     group.sample_size(10); // Fewer samples for slow iterations
-    
+
     let password = PasswordString::new("benchmark-password".to_string());
     let plaintext = b"test data for roundtrip benchmarking";
-    
+
     let iterations = vec![1, 10, 100, 1_000, 10_000, 100_000, 300_000];
-    
+
     for &iters in &iterations {
         let id = BenchmarkId::new("iterations", iters);
         group.bench_with_input(id, &iters, |b, &iters| {
@@ -60,7 +60,7 @@ fn bench_roundtrip_iterations(c: &mut Criterion) {
                     iters,
                 )
                 .unwrap();
-                
+
                 // Decrypt
                 let mut decrypted = Vec::new();
                 decrypt(
@@ -69,12 +69,12 @@ fn bench_roundtrip_iterations(c: &mut Criterion) {
                     black_box(&password),
                 )
                 .unwrap();
-                
+
                 black_box(decrypted);
             });
         });
     }
-    
+
     group.finish();
 }
 
@@ -84,4 +84,3 @@ criterion_group!(
     bench_roundtrip_iterations
 );
 criterion_main!(benches);
-

--- a/benches/kdf.rs
+++ b/benches/kdf.rs
@@ -23,8 +23,7 @@ fn kdf_benches(c: &mut Criterion) {
         group.bench_with_input(id, &iters, |b, &iters| {
             b.iter(|| {
                 let mut key = Key32::new([0u8; 32]);
-                derive_pbkdf2_key(black_box(&pw), black_box(&salt), iters, &mut key)
-                    .unwrap();
+                derive_pbkdf2_key(black_box(&pw), black_box(&salt), iters, &mut key).unwrap();
                 black_box(key);
             });
         });

--- a/src/decryption/decrypt.rs
+++ b/src/decryption/decrypt.rs
@@ -157,7 +157,7 @@ where
     let kdf_iterations = read_kdf_iterations(&mut input, file_version)?;
 
     // Public IV — secure from the start
-    let public_iv: Iv16 = Iv16::from(read_exact_span(&mut input)?);
+    let public_iv: Iv16 = read_exact_span(&mut input)?;
 
     // Setup key — secure buffer from birth
     let mut setup_key = Aes256Key32::new([0u8; 32]);

--- a/src/decryption/mod.rs
+++ b/src/decryption/mod.rs
@@ -31,8 +31,6 @@ pub(crate) mod session;
 pub(crate) mod stream;
 
 pub use decrypt::decrypt;
-pub use read::{
-    consume_all_extensions, read_exact_span, read_file_version, read_kdf_iterations,
-};
+pub use read::{consume_all_extensions, read_exact_span, read_file_version, read_kdf_iterations};
 pub use session::extract_session_data;
 pub use stream::{decrypt_ciphertext_stream, StreamConfig};

--- a/src/decryption/stream/versions.rs
+++ b/src/decryption/stream/versions.rs
@@ -16,8 +16,7 @@ use std::io::{Read, Write};
 
 fn verify_payload_hmac(hmac: HmacSha256, expected: &Trailer32) -> Result<(), AescryptError> {
     let computed = hmac.finalize().into_bytes();
-    let computed_fixed =
-        Trailer32::try_from(computed.as_ref()).expect("computed hmac is 32 bytes");
+    let computed_fixed = Trailer32::try_from(computed.as_ref()).expect("computed hmac is 32 bytes");
     if !computed_fixed.ct_eq(expected) {
         return Err(AescryptError::Header("HMAC verification failed".into()));
     }

--- a/src/kdf/mod.rs
+++ b/src/kdf/mod.rs
@@ -23,4 +23,3 @@
 
 pub mod ackdf;
 pub mod pbkdf2;
-

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -20,4 +20,3 @@ pub const TEST_DATA_SHORT: &[u8] = b"test";
 /// Common iteration count vectors for testing various iteration values
 #[allow(dead_code)] // Used across multiple test files
 pub const TEST_ITERATION_VALUES: &[u32] = &[1, TEST_ITERATIONS, 10];
-

--- a/tests/file_ops_tests.rs
+++ b/tests/file_ops_tests.rs
@@ -5,8 +5,8 @@
 //! from tests/test_data/aes_test_files/
 
 mod common;
-use common::TEST_PASSWORD;
 use common::TEST_ITERATIONS;
+use common::TEST_PASSWORD;
 
 use aescrypt_rs::aliases::PasswordString;
 use aescrypt_rs::decrypt;
@@ -54,11 +54,10 @@ fn load_json_vectors(filename: &str) -> Vec<TestVector> {
         .join("test_data")
         .join(filename);
 
-    let content = std::fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("Failed to read {filename}: {e}"));
+    let content =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("Failed to read {filename}: {e}"));
 
-    serde_json::from_str(&content)
-        .unwrap_or_else(|e| panic!("Failed to parse {filename}: {e}"))
+    serde_json::from_str(&content).unwrap_or_else(|e| panic!("Failed to parse {filename}: {e}"))
 }
 
 // —————————————————————————————————————————————————————————————————————————————
@@ -67,22 +66,22 @@ fn load_json_vectors(filename: &str) -> Vec<TestVector> {
 #[test]
 fn decrypt_actual_v0_files() {
     let password = PasswordString::new(TEST_PASSWORD.to_string());
-    
+
     for i in 0..21 {
         let file_path = get_aes_test_file_path("v0", i);
-        let file = File::open(&file_path)
-            .unwrap_or_else(|e| panic!("Failed to open {file_path:?}: {e}"));
+        let file =
+            File::open(&file_path).unwrap_or_else(|e| panic!("Failed to open {file_path:?}: {e}"));
         let mut reader = BufReader::new(file);
-        
+
         let mut decrypted = Vec::new();
         let result = decrypt(&mut reader, &mut decrypted, &password);
-        
+
         if let Err(e) = result {
             // Some files might be empty (test vector 0), so empty content is valid
             // But decryption should still succeed
             panic!("Failed to decrypt v0 file {i}: {e:?}");
         }
-        
+
         // Note: Empty files are valid (test vector 0 is empty string)
         // So we just verify decryption succeeded, not that content exists
     }
@@ -91,17 +90,17 @@ fn decrypt_actual_v0_files() {
 #[test]
 fn decrypt_actual_v1_files() {
     let password = PasswordString::new(TEST_PASSWORD.to_string());
-    
+
     for i in 0..21 {
         let file_path = get_aes_test_file_path("v1", i);
-        let file = File::open(&file_path)
-            .unwrap_or_else(|e| panic!("Failed to open {file_path:?}: {e}"));
+        let file =
+            File::open(&file_path).unwrap_or_else(|e| panic!("Failed to open {file_path:?}: {e}"));
         let mut reader = BufReader::new(file);
-        
+
         let mut decrypted = Vec::new();
         decrypt(&mut reader, &mut decrypted, &password)
             .unwrap_or_else(|e| panic!("Failed to decrypt v1 file {i}: {e:?}"));
-        
+
         // Note: Empty files are valid (test vector 0 is empty string)
     }
 }
@@ -109,17 +108,17 @@ fn decrypt_actual_v1_files() {
 #[test]
 fn decrypt_actual_v2_files() {
     let password = PasswordString::new(TEST_PASSWORD.to_string());
-    
+
     for i in 0..21 {
         let file_path = get_aes_test_file_path("v2", i);
-        let file = File::open(&file_path)
-            .unwrap_or_else(|e| panic!("Failed to open {file_path:?}: {e}"));
+        let file =
+            File::open(&file_path).unwrap_or_else(|e| panic!("Failed to open {file_path:?}: {e}"));
         let mut reader = BufReader::new(file);
-        
+
         let mut decrypted = Vec::new();
         decrypt(&mut reader, &mut decrypted, &password)
             .unwrap_or_else(|e| panic!("Failed to decrypt v2 file {i}: {e:?}"));
-        
+
         // Note: Empty files are valid (test vector 0 is empty string)
     }
 }
@@ -127,17 +126,17 @@ fn decrypt_actual_v2_files() {
 #[test]
 fn decrypt_actual_v3_files() {
     let password = PasswordString::new(TEST_PASSWORD.to_string());
-    
+
     for i in 0..21 {
         let file_path = get_aes_test_file_path("v3", i);
-        let file = File::open(&file_path)
-            .unwrap_or_else(|e| panic!("Failed to open {file_path:?}: {e}"));
+        let file =
+            File::open(&file_path).unwrap_or_else(|e| panic!("Failed to open {file_path:?}: {e}"));
         let mut reader = BufReader::new(file);
-        
+
         let mut decrypted = Vec::new();
         decrypt(&mut reader, &mut decrypted, &password)
             .unwrap_or_else(|e| panic!("Failed to decrypt v3 file {i}: {e:?}"));
-        
+
         // Note: Empty files are valid (test vector 0 is empty string)
     }
 }
@@ -148,28 +147,33 @@ fn decrypt_actual_v3_files() {
 #[test]
 fn round_trip_from_actual_files() {
     let password = PasswordString::new(TEST_PASSWORD.to_string());
-    
+
     for i in 0..5 {
         // Decrypt original file
         let input_path = get_aes_test_file_path("v3", i);
         let input_file = File::open(&input_path)
             .unwrap_or_else(|e| panic!("Failed to open {input_path:?}: {e}"));
         let mut reader = BufReader::new(input_file);
-        
+
         let mut plaintext = Vec::new();
         decrypt(&mut reader, &mut plaintext, &password)
             .unwrap_or_else(|e| panic!("Failed to decrypt v3 file {i}: {e:?}"));
-        
+
         // Re-encrypt as v3 (encrypt() always creates v3 format)
         let mut re_encrypted = Vec::new();
-        encrypt(Cursor::new(&plaintext), &mut re_encrypted, &password, TEST_ITERATIONS)
-            .unwrap_or_else(|e| panic!("Failed to re-encrypt file {i}: {e:?}"));
-        
+        encrypt(
+            Cursor::new(&plaintext),
+            &mut re_encrypted,
+            &password,
+            TEST_ITERATIONS,
+        )
+        .unwrap_or_else(|e| panic!("Failed to re-encrypt file {i}: {e:?}"));
+
         // Decrypt again
         let mut final_plaintext = Vec::new();
         decrypt(Cursor::new(&re_encrypted), &mut final_plaintext, &password)
             .unwrap_or_else(|e| panic!("Failed to decrypt re-encrypted file {i}: {e:?}"));
-        
+
         assert_eq!(
             plaintext, final_plaintext,
             "Round-trip failed for v3 file {i}"
@@ -188,41 +192,46 @@ fn round_trip_from_actual_files() {
 fn migrate_v0_to_v3() {
     let password = PasswordString::new(TEST_PASSWORD.to_string());
     let vectors = load_json_vectors("test_vectors_v0.json");
-    
+
     // Test all 21 files (or at least 15 for performance)
     let test_count = vectors.len().min(21);
-    
+
     for (i, vector) in vectors.iter().enumerate().take(test_count) {
         // Load expected plaintext from vectors
         let expected_plaintext = vector.plaintext.as_bytes();
-        
+
         // Decrypt v0 file
         let file_path = get_aes_test_file_path("v0", i);
-        let file = File::open(&file_path)
-            .unwrap_or_else(|e| panic!("Failed to open {file_path:?}: {e}"));
+        let file =
+            File::open(&file_path).unwrap_or_else(|e| panic!("Failed to open {file_path:?}: {e}"));
         let mut reader = BufReader::new(file);
-        
+
         let mut decrypted = Vec::new();
         decrypt(&mut reader, &mut decrypted, &password)
             .unwrap_or_else(|e| panic!("Failed to decrypt v0 file {i}: {e:?}"));
-        
+
         // Verify decrypted plaintext matches expected from vectors
         assert_eq!(
             decrypted.as_slice(),
             expected_plaintext,
             "Plaintext mismatch for v0 file {i}"
         );
-        
+
         // Encrypt plaintext as v3 (encrypt() always creates v3 format, we cannot encrypt to v0)
         let mut v3_encrypted = Vec::new();
-        encrypt(Cursor::new(&decrypted), &mut v3_encrypted, &password, TEST_ITERATIONS)
-            .unwrap_or_else(|e| panic!("Failed to encrypt v0→v3 migration for file {i}: {e:?}"));
-        
+        encrypt(
+            Cursor::new(&decrypted),
+            &mut v3_encrypted,
+            &password,
+            TEST_ITERATIONS,
+        )
+        .unwrap_or_else(|e| panic!("Failed to encrypt v0→v3 migration for file {i}: {e:?}"));
+
         // Decrypt v3 encrypted data
         let mut final_plaintext = Vec::new();
         decrypt(Cursor::new(&v3_encrypted), &mut final_plaintext, &password)
             .unwrap_or_else(|e| panic!("Failed to decrypt v3 migrated file {i}: {e:?}"));
-        
+
         // Verify plaintext matches (migration preserved data integrity)
         assert_eq!(
             decrypted, final_plaintext,
@@ -235,41 +244,46 @@ fn migrate_v0_to_v3() {
 fn migrate_v1_to_v3() {
     let password = PasswordString::new(TEST_PASSWORD.to_string());
     let vectors = load_json_vectors("test_vectors_v1.json");
-    
+
     // Test all 21 files (or at least 15 for performance)
     let test_count = vectors.len().min(21);
-    
+
     for (i, vector) in vectors.iter().enumerate().take(test_count) {
         // Load expected plaintext from vectors
         let expected_plaintext = vector.plaintext.as_bytes();
-        
+
         // Decrypt v1 file
         let file_path = get_aes_test_file_path("v1", i);
-        let file = File::open(&file_path)
-            .unwrap_or_else(|e| panic!("Failed to open {file_path:?}: {e}"));
+        let file =
+            File::open(&file_path).unwrap_or_else(|e| panic!("Failed to open {file_path:?}: {e}"));
         let mut reader = BufReader::new(file);
-        
+
         let mut decrypted = Vec::new();
         decrypt(&mut reader, &mut decrypted, &password)
             .unwrap_or_else(|e| panic!("Failed to decrypt v1 file {i}: {e:?}"));
-        
+
         // Verify decrypted plaintext matches expected from vectors
         assert_eq!(
             decrypted.as_slice(),
             expected_plaintext,
             "Plaintext mismatch for v1 file {i}"
         );
-        
+
         // Encrypt plaintext as v3 (encrypt() always creates v3 format, we cannot encrypt to v1)
         let mut v3_encrypted = Vec::new();
-        encrypt(Cursor::new(&decrypted), &mut v3_encrypted, &password, TEST_ITERATIONS)
-            .unwrap_or_else(|e| panic!("Failed to encrypt v1→v3 migration for file {i}: {e:?}"));
-        
+        encrypt(
+            Cursor::new(&decrypted),
+            &mut v3_encrypted,
+            &password,
+            TEST_ITERATIONS,
+        )
+        .unwrap_or_else(|e| panic!("Failed to encrypt v1→v3 migration for file {i}: {e:?}"));
+
         // Decrypt v3 encrypted data
         let mut final_plaintext = Vec::new();
         decrypt(Cursor::new(&v3_encrypted), &mut final_plaintext, &password)
             .unwrap_or_else(|e| panic!("Failed to decrypt v3 migrated file {i}: {e:?}"));
-        
+
         // Verify plaintext matches (migration preserved data integrity)
         assert_eq!(
             decrypted, final_plaintext,
@@ -282,41 +296,46 @@ fn migrate_v1_to_v3() {
 fn migrate_v2_to_v3() {
     let password = PasswordString::new(TEST_PASSWORD.to_string());
     let vectors = load_json_vectors("test_vectors_v2.json");
-    
+
     // Test all 21 files (or at least 15 for performance)
     let test_count = vectors.len().min(21);
-    
+
     for (i, vector) in vectors.iter().enumerate().take(test_count) {
         // Load expected plaintext from vectors
         let expected_plaintext = vector.plaintext.as_bytes();
-        
+
         // Decrypt v2 file
         let file_path = get_aes_test_file_path("v2", i);
-        let file = File::open(&file_path)
-            .unwrap_or_else(|e| panic!("Failed to open {file_path:?}: {e}"));
+        let file =
+            File::open(&file_path).unwrap_or_else(|e| panic!("Failed to open {file_path:?}: {e}"));
         let mut reader = BufReader::new(file);
-        
+
         let mut decrypted = Vec::new();
         decrypt(&mut reader, &mut decrypted, &password)
             .unwrap_or_else(|e| panic!("Failed to decrypt v2 file {i}: {e:?}"));
-        
+
         // Verify decrypted plaintext matches expected from vectors
         assert_eq!(
             decrypted.as_slice(),
             expected_plaintext,
             "Plaintext mismatch for v2 file {i}"
         );
-        
+
         // Encrypt plaintext as v3 (encrypt() always creates v3 format, we cannot encrypt to v2)
         let mut v3_encrypted = Vec::new();
-        encrypt(Cursor::new(&decrypted), &mut v3_encrypted, &password, TEST_ITERATIONS)
-            .unwrap_or_else(|e| panic!("Failed to encrypt v2→v3 migration for file {i}: {e:?}"));
-        
+        encrypt(
+            Cursor::new(&decrypted),
+            &mut v3_encrypted,
+            &password,
+            TEST_ITERATIONS,
+        )
+        .unwrap_or_else(|e| panic!("Failed to encrypt v2→v3 migration for file {i}: {e:?}"));
+
         // Decrypt v3 encrypted data
         let mut final_plaintext = Vec::new();
         decrypt(Cursor::new(&v3_encrypted), &mut final_plaintext, &password)
             .unwrap_or_else(|e| panic!("Failed to decrypt v3 migrated file {i}: {e:?}"));
-        
+
         // Verify plaintext matches (migration preserved data integrity)
         assert_eq!(
             decrypted, final_plaintext,
@@ -331,7 +350,7 @@ fn migrate_v2_to_v3() {
 #[test]
 fn handle_missing_file_gracefully() {
     let non_existent = PathBuf::from("nonexistent_file.aes");
-    
+
     let file = File::open(&non_existent);
     assert!(file.is_err(), "Should fail to open non-existent file");
 }
@@ -342,19 +361,17 @@ fn handle_missing_file_gracefully() {
 #[test]
 fn decrypt_deterministic_v3_files() {
     let password = PasswordString::new(TEST_PASSWORD.to_string());
-    
+
     for i in 0..21 {
         let file_path = get_v3_deterministic_path(i);
-        let file = File::open(&file_path)
-            .unwrap_or_else(|e| panic!("Failed to open {file_path:?}: {e}"));
+        let file =
+            File::open(&file_path).unwrap_or_else(|e| panic!("Failed to open {file_path:?}: {e}"));
         let mut reader = BufReader::new(file);
-        
+
         let mut decrypted = Vec::new();
         decrypt(&mut reader, &mut decrypted, &password)
             .unwrap_or_else(|e| panic!("Failed to decrypt deterministic v3 file {i}: {e:?}"));
-        
+
         // Note: Empty files are valid (test vector 0 is empty string)
     }
 }
-
-

--- a/tests/header_tests.rs
+++ b/tests/header_tests.rs
@@ -137,7 +137,7 @@ fn version_boundary_values() {
         (b"AES\x02\x00".as_slice(), 2u8),
         (b"AES\x03\x00".as_slice(), 3u8),
     ];
-    
+
     for (data, expected) in valid_versions {
         assert_eq!(
             read_version(Cursor::new(data)).unwrap(),
@@ -152,7 +152,7 @@ fn version_boundary_values() {
 fn unsupported_version_boundary_values() {
     // Test versions > 3
     let unsupported_versions = [4u8, 5u8, 10u8, 255u8];
-    
+
     for version in unsupported_versions {
         let data = [b'A', b'E', b'S', version, 0x00];
         let err = read_version(Cursor::new(&data)).unwrap_err();
@@ -167,7 +167,7 @@ fn unsupported_version_boundary_values() {
 fn io_error_on_short_magic_read() {
     // Test I/O error when magic read fails (short read)
     use std::io::{self, Read};
-    
+
     struct ShortReader;
     impl Read for ShortReader {
         fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
@@ -181,11 +181,11 @@ fn io_error_on_short_magic_read() {
             }
         }
     }
-    
+
     let err = read_version(ShortReader).unwrap_err();
     // Should be I/O error from read_exact
     match err {
-        aescrypt_rs::AescryptError::Io(_) => {},
+        aescrypt_rs::AescryptError::Io(_) => {}
         e => panic!("Expected I/O error, got: {:?}", e),
     }
 }
@@ -239,7 +239,7 @@ fn all_version_combinations() {
         (b"AES\x02\x00".as_slice(), 2u8),
         (b"AES\x03\x00".as_slice(), 3u8),
     ];
-    
+
     for (data, expected) in cases {
         assert_eq!(
             read_version(Cursor::new(data)).unwrap(),


### PR DESCRIPTION
## Summary

Closes the remaining v0.2.0 alias / docs / hygiene issues queued against the `claude/check-issue-21-f31MU` branch. Most changes are doc-only or pure renames; no behavior, perf, or signature impact on existing callers.

## Commits

- `fac4d28` **refactor(decryption): wrap extensions discard buffer in `SpanBuffer<256>`** — last raw `[u8; 256]` on the pre-auth read path now auto-zeroizes. (Closes #23.)
- `009bda8` **refactor(aliases): name the extensions chunk buffer `ExtensionChunk256`** — promote the inline `SpanBuffer<256>` to a semantic alias next to `Block16` / `Trailer32`, leaving room for future extension processing.
- `db397fe` **docs(aliases): correct compile-time safety claim** — `secure-gate`'s `fixed_alias!` macro expands to `pub type`, *not* a nominal newtype; same-shape aliases (`Aes256Key32`, `SessionHmacTag32`, `Trailer32`, `SpanBuffer<32>`) are interchangeable. New "Type Identity" section in `src/aliases.rs` docs + stray inline comment fixed. Upstream `secure-gate` docs also reworded (handled separately by owner).
- `2508044` **docs: drop marketing tone from README and CHANGELOG** — replaces "heroic struggle", "ruthlessly purged ... pristine and minimal", "no wasted bytes ... tiny but important", "gold-standard memory safety", "100% bit-perfect", etc. with factual wording or deletions. (Closes #32.)
- `9e7a5de` **refactor(aliases): drop unused `HmacSha512` alias** — defined but never referenced; `Hmac<Sha512>` is used directly via its own imports in `src/kdf/pbkdf2.rs`. (Closes #34.)
- `e554753` **refactor(kdf): rename PBKDF2 output type to `Pbkdf2DerivedKey32`** — the 32 bytes from `derive_pbkdf2_key` are the v3 *setup key*, semantically distinct from the eventual AES session key. Defined with `fixed_alias!` next to the other named secrets. Zero caller ripple (same underlying type as `Aes256Key32`). (Closes #38.)
- `61f2358` **refactor(kdf): rename ACKDF output type to `AckdfDerivedKey32`** — mirror treatment for the v0/v1/v2 setup-key role; also visually separates it from the existing `AckdfHashState32` (intermediate hash state).
- `d0235ed` **docs(changelog): drop inaccurate `no_std` claims** — `read_version` uses `std::io::Read`, secure-gate's RNG no_std-compatibility doesn't transfer to the host crate, and the 0.1.0 entry's `#![no_std]`-core claim was never accurate.
- `8053f91` **chore: clippy + rustfmt cleanup for v0.2.0 acceptance** — fixes the lone `clippy::useless_conversion` at `src/decryption/decrypt.rs:160`; applies rustfmt to flush pre-existing drift across `benches/`, `tests/`, `src/decryption/{mod,decrypt,stream/versions}.rs`, `src/kdf/mod.rs`. `cargo clippy --all-features --no-deps` and `cargo fmt -- --check` both clean.

## Issues closed by merge

This branch auto-closes #23 and #32 via commit trailers. The other 14 originally-open issues in this thread (#21, #22, #26, #27, #29, #30, #31, #33, #34, #35, #36, #37, #38, #39, #40) were closed directly with evidence comments as the work landed; #34 and #38 also carry `Closes #` trailers as belt-and-suspenders.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test --all-features` — 49 unit + 21 vector + 12 doctest, all pass
- [x] `cargo clippy --all-features --no-deps` — no warnings
- [x] `cargo fmt -- --check` — clean
- [ ] `cargo bench` — not run (no signature changes on perf-sensitive paths; reviewer may opt to verify)

## Owner SOP before tagging v0.2.0

These are outside the scope of this PR per prior discussion:

- Bump `Cargo.toml` from `"0.2.0-rc.9"` → `"0.2.0"`.
- (Optional) decide whether to re-export the full alias set at the crate root in `lib.rs` (currently only `PasswordString` is at root; the rest live under `aescrypt_rs::aliases::*`).
- `cargo publish` + `git tag v0.2.0` + push tag.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T2eTo8Rhkkhbzqhh85QHR1)_